### PR TITLE
Mica support on Win32 platform

### DIFF
--- a/src/SlimApp/platforms/win32.h
+++ b/src/SlimApp/platforms/win32.h
@@ -1,6 +1,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-
+#ifdef SA_Win11
+#include <dwmapi.h>
+#endif // optional Windows 11 Mica - Make sure to link to dwmapi.lib!
 #ifndef NDEBUG
 #include <tchar.h>
 #include <stdio.h>
@@ -276,6 +278,12 @@ int APIENTRY WinMain(HINSTANCE hInstance,
             hInstance,
             null
     );
+    #ifdef SA_Win11
+        int wDm = 1;
+        int wBgType = 2;
+        DwmSetWindowAttribute(window,20,&wDm,4);
+        DwmSetWindowAttribute(window,38,&wBgType,4);
+    #endif // optional Windows 11 Mica - Make sure to link to dwmapi.lib!
     if (!window)
         return -1;
 


### PR DESCRIPTION
Adds support for a window to utilize darkmode and Windows 11-style taskbars by defining `SA_Win11` before inclusion of Slimapp. Requires that the app links to `dwmapi.lib`

![image](https://user-images.githubusercontent.com/63971285/149862233-a2c044d2-8e6a-4170-8d05-4e9cfacc7fa7.png)

Note that the changes require Windows 11 Insider Preview 22523 or higher to work for Mica. Before 22523, the only easy way to set Mica was through an undocumented attribute.

Not entirely sure if this is in scope, but was fun to add and figured I might as well PR it in case. Cheers!